### PR TITLE
Fixed #19397: General digest settings table is not updated when changing email

### DIFF
--- a/update/database/ezpublish/5.0/unstable/dbupdate-4.7.0-to-5.0.0alpha1.sql
+++ b/update/database/ezpublish/5.0/unstable/dbupdate-4.7.0-to-5.0.0alpha1.sql
@@ -8,3 +8,12 @@ UPDATE ezcobj_state_group_language SET real_language_id = language_id - bitand(l
 -- dropping the primary key (contentobject_state_group_id, language_id) and creating
 -- the new one (contentobject_state_group_id, real_language_id) are done in the
 -- PHP script after removing the duplicated entries
+
+-- See http://issues.ez.no/19397
+-- Normalize database so that updates to email address automatically affects digest settings
+ALTER TABLE ezgeneral_digest_user_settings ADD user_id integer DEFAULT 0 NOT NULL;
+DELETE FROM ezgeneral_digest_user_settings WHERE address NOT IN (SELECT email FROM ezuser);
+UPDATE ezgeneral_digest_user_settings SET user_id = (SELECT ezuser.contentobject_id
+           FROM ezuser WHERE ezuser.email = ezgeneral_digest_user_settings.address);
+CREATE UNIQUE INDEX ezgeneral_digest_user_id ON ezgeneral_digest_user_settings (user_id);
+ALTER TABLE ezgeneral_digest_user_settings DROP COLUMN address;


### PR DESCRIPTION
Oracle part of https://github.com/ezsystems/ezpublish/pull/415
