### PR TITLE
Fixed EZP-19833: ORA-01758 on migration from 2.3 to 2.4

### DIFF
--- a/update/database/ezpublish/4.7/unstable/dbupdate-4.6.0-to-4.7.0alpha1.sql
+++ b/update/database/ezpublish/4.7/unstable/dbupdate-4.6.0-to-4.7.0alpha1.sql
@@ -2,7 +2,9 @@ UPDATE ezsite_data SET value='4.7.0alpha1' WHERE name='ezpublish-version';
 UPDATE ezsite_data SET value='1' WHERE name='ezpublish-release';
 
 
-ALTER TABLE ezpending_actions ADD id integer NOT NULL;
+ALTER TABLE ezpending_actions ADD id integer;
+UPDATE ezpending_actions SET id = -ROWNUM;
+ALTER TABLE ezpending_actions MODIFY id integer NOT NULL;
 
 CREATE SEQUENCE s_pending_actions_incr;
 CREATE OR REPLACE TRIGGER ezpending_actions_id_tr


### PR DESCRIPTION
It's not possible to add "NOT NULL" columns into tables with existing data.
Through this patch, existing rows get a unique, negative, value on ID field. Should it be set to a positive value and sequence creation changed to start from last id? 
