### PR TITLE
Fixed #20824: ezoracledb->generateSQLINStatement - not working correctly for items > 1000

### DIFF
--- a/ezdb/dbms-drivers/ezoracledb.php
+++ b/ezdb/dbms-drivers/ezoracledb.php
@@ -1179,7 +1179,7 @@ class eZOracleDB extends eZDBInterface
                 }
                 $offset += $length;
             }
-            $result = $columnName . ' ' . implode( $connector . ' ' . $columnName, $parts );
+            $result = ' ( ' . $columnName . implode( $connector . ' ' . $columnName, $parts ) . ' ) ';
         }
         else
         {


### PR DESCRIPTION
all credit should goes to Felix Woldt (Thank you, sir)

This patch enforces that **OR** clauses are encapsulated in braces ( **(** ... **)** ) , on the referred method

Sample test case:

``` php
$db = eZDB::instance();
$idList = range( 1,  2005 );
$sqlINString = $db->generateSQLINStatement( $idList, ' table_name.id', false, false, 'int' );
$cli->output( "select * from table_name where $sqlINString and cond=1" );
```

(without the patch, "cond=1" is only combined with the last remaining 5 id's)
