### PR TITLE
Fix EZP-21585: ORA-12899 when creating content in japanese

### DIFF
--- a/ezdb/dbms-drivers/ezoracledb.php
+++ b/ezdb/dbms-drivers/ezoracledb.php
@@ -1293,6 +1293,33 @@ class eZOracleDB extends eZDBInterface
         $value = array_combine( $params[1], $value );
     }
 
+    /**
+     * {@inheritdoc}
+     *
+     * Oracle's strings are truncated counting bytes instead of char
+     */
+    public function truncateString( $string, $maxLength, $fieldName, $truncationSuffix = '' )
+    {
+        if ( strlen( $string ) <= $maxLength )
+        {
+            return $string;
+        }
+
+        eZDebug::writeDebug( $string, "truncation of $fieldName to max_length=". $maxLength );
+
+        return mb_strcut( $string, 0, $maxLength - strlen( $truncationSuffix ), "utf-8" );
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * Oracle's string's size are bytes instead of char
+     */
+    public function countStringSize( $string )
+    {
+        return strlen( $string );
+    }
+
     /// \privatesection
     /// Database connection
     var $DBConnection;


### PR DESCRIPTION
Link: https://jira.ez.no/browse/EZP-21585
### Description

ezoracle's field sizes are set in bytes instead and not char (like mysql) and is not able to automatically trim strings (and that's a good thing because it might break some unicode chars at the end of strings).

This PR provides trimming and counting functions for ezoracle not to break with long unicode strings.

This code will be executed only if used along with the related ezpublish-legacy patch: https://github.com/ezsystems/ezpublish-legacy/pull/811

The goal of this pull request is not to make ezoracle behave the same way mysql does, it is to stop it from breaking. We will need to document the fact the ezoracle counts the size of string length using bytes.
### Tests

Manual tests
