### PR TITLE
Fix EZP-21585: set correct col. length for oracle

### DIFF
--- a/settings/dbschema.ini.append.php
+++ b/settings/dbschema.ini.append.php
@@ -8,21 +8,21 @@ ColumnNameTranslation[ezenumobjectvalue.contentobject_attribute_version]=content
 ColumnNameTranslation[ezurl_object_link.contentobject_attribute_version]=contentobject_attr_version
 ColumnNameTranslation[ezdbfile.size]=filesize
 
-ColumnTypeTranslation[ezurlalias.source_url]=longtext;varchar(3000)
-ColumnTypeTranslation[ezurl.url]=longtext;varchar(3000)
-ColumnTypeTranslation[ezurlalias_ml.action]=longtext;varchar(3000)
-ColumnTypeTranslation[ezurlalias_ml.text]=longtext;varchar(3000)
-ColumnTypeTranslation[ezurlalias.destination_url]=longtext;varchar(3000)
-ColumnTypeTranslation[ezcontentobject_tree.path_identification_string]=longtext;varchar(3100)
-ColumnTypeTranslation[ezcontentobject_trash.path_identification_string]=longtext;varchar(3100)
-ColumnTypeTranslation[ezimagefile.filepath]=longtext;varchar(3000)
-ColumnTypeTranslation[eznotificationcollection.data_subject]=longtext;varchar(3100)
-ColumnTypeTranslation[ezrss_import.url]=longtext;varchar(3100)
-ColumnTypeTranslation[ezrss_import.import_description]=longtext;varchar(3100)
-ColumnTypeTranslation[ezcontentclass.serialized_name_list]=longtext;varchar(3100)
-ColumnTypeTranslation[ezcontentclass_attribute.serialized_name_list]=longtext;varchar(3100)
-ColumnTypeTranslation[ezpending_actions.param]=longtext;varchar(3000)
-ColumnTypeTranslation[ezcontentclass.serialized_description_list]=longtext;varchar(3000)
+ColumnTypeTranslation[ezurlalias.source_url]=longtext;varchar(1000)
+ColumnTypeTranslation[ezurl.url]=longtext;varchar(1000)
+ColumnTypeTranslation[ezurlalias_ml.action]=longtext;varchar(1000)
+ColumnTypeTranslation[ezurlalias_ml.text]=longtext;varchar(1000)
+ColumnTypeTranslation[ezurlalias.destination_url]=longtext;varchar(1000)
+ColumnTypeTranslation[ezcontentobject_tree.path_identification_string]=longtext;varchar(1000)
+ColumnTypeTranslation[ezcontentobject_trash.path_identification_string]=longtext;varchar(1000)
+ColumnTypeTranslation[ezimagefile.filepath]=longtext;varchar(1000)
+ColumnTypeTranslation[eznotificationcollection.data_subject]=longtext;varchar(1000)
+ColumnTypeTranslation[ezrss_import.url]=longtext;varchar(1000)
+ColumnTypeTranslation[ezrss_import.import_description]=longtext;varchar(1000)
+ColumnTypeTranslation[ezcontentclass.serialized_name_list]=longtext;varchar(1000)
+ColumnTypeTranslation[ezcontentclass_attribute.serialized_name_list]=longtext;varchar(1000)
+ColumnTypeTranslation[ezpending_actions.param]=longtext;varchar(1000)
+ColumnTypeTranslation[ezcontentclass.serialized_description_list]=longtext;varchar(1000)
 
 # Translation of column options, such as NOT NULL and DEFAULT xxx.
 # Currently only "null" (remove "NOT NULL" requirement) is supported.

--- a/update/database/ezoracle/5.0/dbupdate-5.0.0-5.0.1.sql
+++ b/update/database/ezoracle/5.0/dbupdate-5.0.0-5.0.1.sql
@@ -1,0 +1,17 @@
+SET SERVEROUTPUT ON
+
+DECLARE
+    CURSOR table_cur IS
+        SELECT table_name, column_name, data_length
+        FROM user_tab_cols
+        WHERE data_type = 'VARCHAR2' AND ( char_used IS NULL OR char_used = 'B' );
+BEGIN
+    FOR t_rec IN table_cur LOOP
+        IF ( t_rec.data_length > 1000 ) THEN
+            DBMS_OUTPUT.PUT_LINE( 'Column ' || t_rec.table_name || '.' || t_rec.column_name || ' is too wide to fit utf8 VARCHAR: ' || t_rec.data_length || ' shortened to 1000' );
+            t_rec.data_length := 1000;
+        END IF;
+        EXECUTE IMMEDIATE 'ALTER TABLE ' || t_rec.table_name || ' MODIFY ( ' || t_rec.column_name || ' VARCHAR2( ' || t_rec.data_length || ' CHAR ) )';
+    END LOOP;
+END;
+/


### PR DESCRIPTION
I detail: properly declare all oracle columns lengths using CHAR semantics, to allow for UTF8.
While at it, set the length for all BLOBS we shorten to 4k instead of arbitrary 3000 or 3100

Meant to replace both https://github.com/ezsystems/ezoracle/pull/18 and https://github.com/ezsystems/ezpublish-legacy/pull/811
